### PR TITLE
Cleanup caravan world object comps after launch and fix compatibility with Colony Groups

### DIFF
--- a/Source/SRTS/CompLaunchableSRTS.cs
+++ b/Source/SRTS/CompLaunchableSRTS.cs
@@ -577,8 +577,8 @@ namespace SRTS
 		                  thingsInsideShip.Clear();
 
 		                  cafr.RemoveAllPawns();
-		                  if(cafr.Spawned)
-			                    Find.WorldObjects.Remove((WorldObject) cafr);
+		                  if(!cafr.Destroyed)
+			                    cafr.Destroy();
 		                  TravelingSRTS travelingTransportPods = (TravelingSRTS) WorldObjectMaker.MakeWorldObject(DefDatabase<WorldObjectDef>.GetNamed("TravelingSRTS", true));
 		                  travelingTransportPods.Tile = cafr.Tile;
 		                  travelingTransportPods.SetFaction(Faction.OfPlayer);


### PR DESCRIPTION
**Problem.** If you launch a ship from a caravan on the world map, e.g. trading at a settlement, then associated world object comps and patches to caravan destruction may not trigger.

**Known incompatibility.** The Colony Groups mod patches the method `Caravan.Destroy` to rearrange pawn groups after caravan destruction; however, the current SRTS implementation never calls `Caravan.Destroy` when destroying caravans, which may also cause downstream world object comps associated with the caravan to never trigger.

_Note._ Calling `Caravan.Destroy` seems to be the standard in vanilla for cleaning up caravans (see `CaravanEnterMapUtility` and `CaravanMergeUtility` for examples of usage).

The commit provided was neither compiled nor tested (because the source appears to be missing a few files), so feel free to edit these changes.